### PR TITLE
Add new settings to retrieve and display values and better highlighting of the selections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,9 @@ Installation
    -  ``many`` must be ``True`` for ``ManyToManyField`` and ``False``
       for ``ForeignKey``.
    -  ``limit`` (optional) specifies the maximum count of entries to retrieve.
+   -  ``load_on_empty`` (optional, default ``False``) whether to show the
+      first options available (up to limit) when the input gets the focus
+      and it's empty.
 
 Example app
 ===========

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,8 @@ Installation
    -  ``load_on_empty`` (optional, default ``False``) whether to show the
       first options available (up to limit) when the input gets the focus
       and it's empty.
+   -  ``display_deleted`` (optional, default ``True``) display elements in
+      the "chips" section even if they were deleted from the "foreign" model.
 
 Example app
 ===========

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ So the mapping is as follow:
    class Blog(models.Model):
        tags = ArrayField(models.CharField(max_length=255), blank=True, default=list)
 
-Anf the mapping of the table where you have all the possible tags:
+And the mapping of the table where you have all the possible tags:
 
 .. code:: python
 

--- a/example/example/admin.py
+++ b/example/example/admin.py
@@ -10,7 +10,7 @@ class CatAdminForm(forms.ModelForm):
         exclude = ()
         widgets = {
             'favorite_foods': SearchableSelect(model='example.Food', search_field='name', many=True, limit=20),
-            'owner': SearchableSelect(model='example.Person', search_field='name', many=False),
+            'owner': SearchableSelect(model='example.Person', search_field='name', load_on_empty=True, many=False),
         }
 
 

--- a/example/tests.py
+++ b/example/tests.py
@@ -16,10 +16,10 @@ class GenericTest(test.LiveServerTestCase):
     """
     def setUp(self):
         chrome_options = Options()
-        chrome_options.add_argument('--headless')
+        chrome_options.headless = True
         self.selenium = webdriver.Chrome(options=chrome_options)
         # self.selenium.maximize_window()
-        super(GenericTest, self).setUp()
+        super().setUp()
 
         self.admin = User.objects.create(username='admin', is_superuser=True, is_staff=True)
         self.admin.set_password('admin')

--- a/searchableselect/static/searchableselect/main.js
+++ b/searchableselect/static/searchableselect/main.js
@@ -65,7 +65,12 @@
 
             objects.initialize();
 
-            $element.typeahead(null, {
+            var thInit = {highlight: true};
+            if ($element.attr('data-load-on-empty') === 'True') {
+                thInit.minLength = 0;
+            }
+
+            $element.typeahead(thInit, {
                 name: 'objects',
                 source: objects.ttAdapter(),
                 displayKey: 'matched_name',

--- a/searchableselect/static/searchableselect/main.js
+++ b/searchableselect/static/searchableselect/main.js
@@ -104,13 +104,20 @@
                     }, 200);
                 });
 
+                var url = $select.attr('data-url');
+                var model = $select.attr('data-model');
+                var search_field = $select.attr('data-search-field');
+                var lookup_field = $select.attr('data-lookup-field');
+                var limit = $select.attr('data-limit');
+                var many = $select.attr('data-many');
+                var name = $select.attr('data-name');
                 $select.completion({
-                    url: $select.attr('data-url') + '?model=' + $select.attr('data-model') + '&search_field=' + $select.attr('data-search-field') + '&limit=' + $select.attr('data-limit') + '&q=',
+                    url: url + '?model=' + model + '&search_field=' + search_field + '&lookup_field=' + lookup_field + '&limit=' + limit + '&q=',
                     onSelect: function (data) {
                         var $chip = $('<div/>').addClass('chip minimized').html(data.name).append(
-                            $('<input/>').attr('type', 'hidden').attr('name', $select.attr('data-name')).attr('value', data.pk)
+                            $('<input/>').attr('type', 'hidden').attr('name', name).attr('value', data[lookup_field])
                         );
-                        if($select.attr('data-many') == '1') {
+                        if(many == '1') {
                             $chips.append($chip);
                         } else {
                             $chips.html($chip);

--- a/searchableselect/templates/searchableselect/select.html
+++ b/searchableselect/templates/searchableselect/select.html
@@ -8,6 +8,7 @@
     data-model="{{ model }}"
     data-search-field="{{ search_field }}"
     data-lookup-field="{{ lookup_field }}"
+    data-load-on-empty="{{ load_on_empty }}"
     data-limit="{{ limit }}"
     data-many="{% if many %}1{% else %}0{% endif %}"
     class="searchable-select"

--- a/searchableselect/templates/searchableselect/select.html
+++ b/searchableselect/templates/searchableselect/select.html
@@ -7,6 +7,7 @@
     data-name="{{ field_name }}"
     data-model="{{ model }}"
     data-search-field="{{ search_field }}"
+    data-lookup-field="{{ lookup_field }}"
     data-limit="{{ limit }}"
     data-many="{% if many %}1{% else %}0{% endif %}"
     class="searchable-select"
@@ -18,8 +19,8 @@
 <div id="{{ field_id }}-chips" class="chips">
     {% for value in values %}
         <div class="chip">
-        {{ value }}
-        <input type="hidden" name="{{ field_name }}" value="{{ value.pk }}" />
+        {{ value.name }}
+        <input type="hidden" name="{{ field_name }}" value="{{ value.value }}" />
         </div>
     {% endfor %}
 </div>

--- a/searchableselect/views.py
+++ b/searchableselect/views.py
@@ -10,6 +10,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 def filter_models(request):
     model_name = request.GET.get('model')
     search_field = request.GET.get('search_field')
+    lookup_field = request.GET.get('lookup_field')
     value = request.GET.get('q')
     limit = int(request.GET.get('limit', 10))
     try:
@@ -21,9 +22,7 @@ def filter_models(request):
 
     values = model.objects.filter(**{'{}__icontains'.format(search_field): value})[:limit]
     values = [
-        dict(pk=v.pk, name=smart_str(v))
-        for v
-        in values
+        {lookup_field: getattr(v, lookup_field), 'name': smart_str(v)} for v in values
     ]
 
     return JsonResponse(dict(result=values))

--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -31,6 +31,7 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
         self.model = kwargs.pop('model')
         self.search_field = kwargs.pop('search_field')
         self.lookup_field = kwargs.pop('lookup_field', 'pk')
+        self.load_on_empty = kwargs.pop('load_on_empty', False)
         self.many = kwargs.pop('many', True)
         self.limit = int(kwargs.pop('limit', 10))
 
@@ -64,6 +65,7 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
             model=self.model,
             search_field=self.search_field,
             lookup_field=self.lookup_field,
+            load_on_empty=self.load_on_empty,
             limit=self.limit,
             many=self.many
         ))

--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -32,6 +32,7 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
         self.search_field = kwargs.pop('search_field')
         self.lookup_field = kwargs.pop('lookup_field', 'pk')
         self.load_on_empty = kwargs.pop('load_on_empty', False)
+        self.display_deleted = kwargs.pop('display_deleted', True)
         self.many = kwargs.pop('many', True)
         self.limit = int(kwargs.pop('limit', 10))
 
@@ -55,6 +56,14 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
         values = [
             {'name': str(v), 'value': getattr(v, self.lookup_field)} for v in queryset
         ]
+
+        if self.display_deleted and len(values) < len(value):
+            # If  there are fewer values retrieved than
+            # values passed -> elements were deleted from the foreign model, so
+            # if self.display_deleted is True -> append them at the end
+            # of the final list of "chips" displayed (this case should be uncommon).
+            for v in filter(lambda x: x not in map(lambda l: l['value'], values), value):
+                values.append({'name': str(v), 'value': v})
 
         final_attrs = self.build_attrs(attrs, extra_attrs={'name': name})
 

--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -49,7 +49,11 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
                 # as strings with comma separated values
                 value = value.split(',')
             else:
-                value = [value]
+                if value == '':
+                    # Empty ArrayField are serialized as ''
+                    value = []
+                else:
+                    value = [value]
 
         queryset = get_model(self.model).objects.filter(**{'{}__in'.format(self.lookup_field): value})
 

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,62 @@ Example app
 
 Just run the project from `example` directory, head to http://127.0.0.1:8000, login as ``admin``/``admin`` and try adding Cats!
 
+The ``lookup_field`` argument and ``ArrayField``
+================================================
+
+*(New)*
+
+There is one more argument that can be passed to the ``SearchableSelect`` constructor,
+the ``lookup_field``, that by default is ``pk`` (the primary key whatever the
+name is). The field chosen from the model is the one that will be returned as result.
+This is specially useful with the
+`ArrayField <https://docs.djangoproject.com/en/4.0/ref/contrib/postgres/fields/#django.contrib.postgres.fields.ArrayField>`_,
+where we may want to store string values from another table, but not the ids.
+
+Example
+~~~~~~~
+
+You have a ``Blog`` model that has multiple "tags", and you have
+a table with all the valid tags, but you don't want a **many-to-many**
+relation because it is inefficient, so instead you use a
+`Array field from Postgres <https://www.postgresql.org/docs/current/arrays.html>`_,
+where you store only the "label" of the tags, not the ids.
+
+So the mapping is as follow:
+
+.. code:: python
+
+   class Blog(models.Model):
+       tags = ArrayField(models.CharField(max_length=255), blank=True, default=list)
+
+Anf the mapping of the table where you have all the possible tags:
+
+.. code:: python
+
+   class Tag(models.Model):
+       label = models.CharField(unique=True, max_length=255)
+       def __str__(self):
+           return self.label
+
+So now the configuration in the Admin to query the tags and store the values
+from the ``label`` field instead of the primary key value would be as follow:
+
+.. code:: python
+
+   class BlogForm(forms.ModelForm):
+       class Meta:
+           model = Blog
+           exclude = ()
+           widgets = {
+               'tags': SearchableSelect(
+                   model='blogs.Tag', search_field='label', lookup_field='label', many=True, limit=10),
+           }
+   
+   @admin.register(Blog)
+   class BlogAdmin(admin.ModelAdmin):
+       form = BlogForm
+
+
 Supported versions
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-searchable-select',
-    version='2.0b1',
+    version='2.0b2',
     description='django-searchable-select - a better and faster multiple selection widget with suggestions for Django',
     long_description="""django-searchable-select
 ========================
@@ -116,6 +116,9 @@ Installation
       for ``ForeignKey``.
    -  ``limit`` (optional) specifies the maximum count of entries to retrieve.
       Defaults to 10.
+   -  ``load_on_empty`` (optional, default ``False``) whether to show the
+      first options available (up to limit) when the input gets the focus
+      and it's empty.
 
 Example app
 ===========

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ Installation
    -  ``load_on_empty`` (optional, default ``False``) whether to show the
       first options available (up to limit) when the input gets the focus
       and it's empty.
+   -  ``display_deleted`` (optional, default ``True``) display elements in
+      the "chips" section even if they were deleted from the "foreign" model.
 
 Example app
 ===========


### PR DESCRIPTION
* New setting `lookup_field`: allows to retrieve and store a different value than the pk of the foreign model: specially useful when used with the `ArrayField` field type (optional, default `pk`).
* New setting `load_on_empty`: allows to load the first elements available when the input gets the focus, and it's empty (optional, disabled by default).
* New option `display_deleted`: display elements in the "chips" section even if they were deleted from the "foreign" model (optional, default `True`).
* Highlight the substrings in the filtered data that match the user input.

Until not merged upstream, it can be installed with:

    $ pip install git+https://github.com/mrsarm/django-searchable-select.git@af194a86c1b4ece7e2424457a35d49dc40d9abda#egg=django-searchable-select

Or just add into the `requirements.txt` file: `git+https://github.com/mrsarm/django-searchable-select.git@af194a86c1b4ece7e2424457a35d49dc40d9abda#egg=django-searchable-select`.